### PR TITLE
Add nav link and tests

### DIFF
--- a/DetectorEstafaCR.Tests/DetectionTests.cs
+++ b/DetectorEstafaCR.Tests/DetectionTests.cs
@@ -1,0 +1,44 @@
+using DetectorEstafaCR.Controllers;
+using DetectorEstafaCR.Data;
+using DetectorEstafaCR.Models;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace DetectorEstafaCR.Tests;
+
+public class DetectionTests
+{
+    private static ApplicationDbContext GetInMemoryDb()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        return new ApplicationDbContext(options);
+    }
+
+    [Fact]
+    public async Task Detect_Flags_Message_With_Keyword()
+    {
+        using var db = GetInMemoryDb();
+        var controller = new HomeController(Microsoft.Extensions.Logging.Abstractions.NullLogger<HomeController>.Instance, db);
+        var input = new DetectInputModel { ContactInfo = "test@example.com", Message = "Ganaste un premio" };
+
+        var result = await controller.Detect(input) as ViewResult;
+        Assert.NotNull(result);
+        var model = Assert.IsType<DetectResultViewModel>(result.Model);
+        Assert.True(model.IsPotentialScam);
+    }
+
+    [Fact]
+    public async Task Detect_NotFlag_When_No_Indicators()
+    {
+        using var db = GetInMemoryDb();
+        var controller = new HomeController(Microsoft.Extensions.Logging.Abstractions.NullLogger<HomeController>.Instance, db);
+        var input = new DetectInputModel { ContactInfo = "user@example.com", Message = "Hola, ¿cómo estás?" };
+
+        var result = await controller.Detect(input) as ViewResult;
+        Assert.NotNull(result);
+        var model = Assert.IsType<DetectResultViewModel>(result.Model);
+        Assert.False(model.IsPotentialScam);
+    }
+}

--- a/DetectorEstafaCR.Tests/DetectorEstafaCR.Tests.csproj
+++ b/DetectorEstafaCR.Tests/DetectorEstafaCR.Tests.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="7.0.20" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.6" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\DetectorEstafaCR\DetectorEstafaCR.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/DetectorEstafaCR.Tests/Usings.cs
+++ b/DetectorEstafaCR.Tests/Usings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/DetectorEstafaCR.sln
+++ b/DetectorEstafaCR.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.9.34728.123
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DetectorEstafaCR", "DetectorEstafaCR\DetectorEstafaCR.csproj", "{AA1453DE-6448-4C90-8D3C-99FD02980AAD}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DetectorEstafaCR.Tests", "DetectorEstafaCR.Tests\DetectorEstafaCR.Tests.csproj", "{2499EF37-A75F-4F3A-9D3D-EAD1A62898E1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{AA1453DE-6448-4C90-8D3C-99FD02980AAD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{AA1453DE-6448-4C90-8D3C-99FD02980AAD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{AA1453DE-6448-4C90-8D3C-99FD02980AAD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2499EF37-A75F-4F3A-9D3D-EAD1A62898E1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2499EF37-A75F-4F3A-9D3D-EAD1A62898E1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2499EF37-A75F-4F3A-9D3D-EAD1A62898E1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2499EF37-A75F-4F3A-9D3D-EAD1A62898E1}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/DetectorEstafaCR/Program.cs
+++ b/DetectorEstafaCR/Program.cs
@@ -12,6 +12,13 @@ builder.Services.AddControllersWithViews();
 
 var app = builder.Build();
 
+// Apply pending migrations at startup
+using (var scope = app.Services.CreateScope())
+{
+    var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+    db.Database.Migrate();
+}
+
 // Configure the HTTP request pipeline.
 if (!app.Environment.IsDevelopment())
 {

--- a/DetectorEstafaCR/Views/Shared/_Layout.cshtml
+++ b/DetectorEstafaCR/Views/Shared/_Layout.cshtml
@@ -23,6 +23,9 @@
                             <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="Index">Home</a>
                         </li>
                         <li class="nav-item">
+                            <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="Detect">Detector</a>
+                        </li>
+                        <li class="nav-item">
                             <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="Privacy">Privacy</a>
                         </li>
                     </ul>


### PR DESCRIPTION
## Summary
- show Detector link in the navbar
- apply EF Core migrations automatically at startup
- add xUnit test project for HomeController detection logic

## Testing
- `dotnet build`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_684f35bc85fc8326843101e77781ccbd